### PR TITLE
fix(fields): changed fields input to map[string]string to simplify

### DIFF
--- a/dynastore_test.go
+++ b/dynastore_test.go
@@ -261,8 +261,8 @@ func testAtomicPutIndex(t *testing.T, dSession Session) {
 		timeStamp := "20200103T1100Z"
 
 		// Put the key
-		err := kv.Put(key, WriteWithBytes(value), WriteWithFields(map[string]*dynamodb.AttributeValue{
-			"created": {S: aws.String(timeStamp)},
+		err := kv.Put(key, WriteWithBytes(value), WriteWithFields(map[string]string{
+			"created": timeStamp,
 		}))
 		assert.NoError(err)
 

--- a/example_test.go
+++ b/example_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/wolfeidau/dynastore"
 )
 
@@ -25,9 +23,10 @@ type Index struct {
 	Created string `json:"created"`
 }
 
-func (cf *Index) ToFields() map[string]*dynamodb.AttributeValue {
-	attr, _ := dynamodbattribute.MarshalMap(cf)
-	return attr
+func (cf *Index) ToFields() map[string]string {
+	return map[string]string{
+		"created": cf.Created,
+	}
 }
 
 func ExamplePartition_AtomicPut() {

--- a/options.go
+++ b/options.go
@@ -67,9 +67,15 @@ func WriteWithString(val string) WriteOption {
 }
 
 // WriteWithFields assign fields to the top level record, this is used to assign attributes used in indexes
-func WriteWithFields(fields map[string]*dynamodb.AttributeValue) WriteOption {
+func WriteWithFields(fields map[string]string) WriteOption {
+	attr := map[string]*dynamodb.AttributeValue{}
+
+	for k, v := range fields {
+		attr[k] = &dynamodb.AttributeValue{S: aws.String(v)}
+	}
+
 	return func(opts *WriteOptions) {
-		opts.fields = fields
+		opts.fields = attr
 	}
 }
 


### PR DESCRIPTION
The aim here is to not leak AWS SDK types were possible.
